### PR TITLE
Fix the bug when try to iterate over a None object or iterate over ke…

### DIFF
--- a/libmich/asn1/PER.py
+++ b/libmich/asn1/PER.py
@@ -1914,8 +1914,9 @@ class PER(ASN1.ASN1Codec):
                         comp_obj._build_constructed_rootext()
                         buf = self._unwrap_open_type(obj, buf, comp_obj)
                         # assign values and clean up content objects
-                        for name in comp:
-                            obj._val[name] = comp_obj._val[name]
+                        if comp_obj._val:
+                            for name in comp_obj._val:
+                                obj._val[name] = comp_obj._val[name]
                         comp_obj._val = None
                 else:
                     # 5) unknown extended field


### PR DESCRIPTION
The old code would throw an exception if `comp_obj._val` is `None` when trying to decode the 'UL-DCCH-Message'. It also happens that the iteration is on `comp`.

Fix both errors and tested on some messages and decoded results match results from OSSNokalva.