### PR TITLE
asn1: add basic support for SEQUENCE value parsing

### DIFF
--- a/libmich/asn1/ASN1.py
+++ b/libmich/asn1/ASN1.py
@@ -3,7 +3,7 @@
 # * Software Name : libmich 
 # * Version : 0.2.3
 # *
-# * Copyright © 2014. Benoit Michau. ANSSI.
+# * Copyright Â© 2014. Benoit Michau. ANSSI.
 # *
 # * This program is free software: you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License version 2 as published
@@ -1063,6 +1063,8 @@ class ASN1Obj(object):
                 return self._parse_value_class(text)
             elif self._type == TYPE_CHOICE:
                 return self._parse_value_choice(text)
+            elif self._type == TYPE_SEQ:
+                return self._parse_value_seq(text)
             else:
                 # TODO: support constructed type value parsing
                 if self._SAFE_COMP:
@@ -1110,6 +1112,9 @@ class ASN1Obj(object):
     
     def _parse_value_choice(self, text=''):
         return parsers.parse_value_choice(self, text)
+    
+    def _parse_value_seq(self, text=''):
+        return parsers.parse_value_seq(self, text)
     
     def parse_set(self, text=''):
         return parsers.parse_set(self, text)

--- a/libmich/asn1/parsers.py
+++ b/libmich/asn1/parsers.py
@@ -1156,7 +1156,29 @@ def parse_value_choice(Obj, text=''):
     return text
 
 def parse_value_seq(Obj, text=''):
-    raise(ASN1_PROC_NOSUPP)
+    # { procedureCode id-cellSetup, ddMode fdd }
+    text, text_val = extract_curlybrack(text)
+    if text_val is None:
+        return text
+    # sequence of values
+    coma_offsets = [-1] + search_top_lvl_sep(text, ',') + [len(text)]
+    values = map(stripper, [text[coma_offsets[i]+1:coma_offsets[i+1]] \
+                                for i in range(len(coma_offsets)-1)])
+    #
+    for val in values:
+        #
+        m = SYNT_RE_IDENT.match(val)
+        if m:
+            # single identified component
+            name = m.group(1)
+            val = val[m.end():].strip()
+            val = Obj['cont'][name].parse_value(val)
+        #
+        if val:
+            raise(ASN1_PROC_TEXT('%s: invalid SEQUENCE value: %s'\
+                  % (Obj.get_fullname(), val)))
+    #
+    return text
 
 def parse_value_set(Obj, text=''):
     raise(ASN1_PROC_NOSUPP)


### PR DESCRIPTION
The NBAP ASN.1 specification 25.433 version 9.10.0 from 2013-12-19 can be compiled using this patch.